### PR TITLE
Fix: correctly distinguish between CAN frames with extended CAN ID and with standard CAN ID.

### DIFF
--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -515,7 +515,11 @@ static void x8h7_can_hw_tx(struct x8h7_can_priv *priv, struct can_frame *frame)
 
   DBG_PRINT("\n");
 
-  can_msg.field.id  = frame->can_id;
+  if (frame->can_id & CAN_EFF_FLAG)
+    can_msg.field.id  = CAN_EFF_FLAG | (frame->can_id & CAN_EFF_MASK);
+  else
+    can_msg.field.id  =                (frame->can_id & CAN_SFF_MASK);
+
   can_msg.field.len = (frame->can_dlc <= CAN_FRAME_MAX_DATA_LEN) ? frame->can_dlc : CAN_FRAME_MAX_DATA_LEN;
   memcpy(can_msg.field.data, frame->data, can_msg.field.len);
 

--- a/recipes-kernel/linux-firmware/linux-firmware-arduino-portenta-x8-stm32h7_git.bb
+++ b/recipes-kernel/linux-firmware/linux-firmware-arduino-portenta-x8-stm32h7_git.bb
@@ -16,7 +16,7 @@ SRC_URI = " \
     file://monitor-m4-elf-file.path \
     file://monitor-m4-elf-file.service \
 "
-SRCREV = "f78b86b9befae74a4222b4dfb0cb910820ab94b8"
+SRCREV = "96bcacb22b87f6f9169d1d01d531a4de641a3d63"
 PV = "0.0.2"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Works in tandem with https://github.com/arduino/portentax8-stm32h7-fw/pull/12.