### PR TITLE
[x8h7_can] fix: there are only 64 filters for extended CAN IDs.

### DIFF
--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -876,7 +876,8 @@ static ssize_t x8h7_can_ef_show(struct device *dev,
   int                   i;
 
   len = 0;
-  for (i=0; i<X8H7_STD_FLT_MAX; i++) {
+  for (i = 0; i < X8H7_EXT_FLT_MAX; i++)
+  {
     if (priv->ext_flt[i].mask) {
       len += snprintf(buf + len, PAGE_SIZE - len,
                       "%02X %08X %08X\n",


### PR DESCRIPTION
Current code causes illegal memory access.