### PR TITLE
[x8h7_can] Fix extended CAN ID when configuring can filter (and use the same struct in both firmware and linux driver)

### DIFF
--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -97,7 +97,7 @@ union x8h7_can_filter_message
 
 /**
  */
-union x8h7_can_message
+union x8h7_can_frame_message
 {
   struct __attribute__((packed))
   {
@@ -283,7 +283,7 @@ static void x8h7_can_hook(void *arg, x8h7_pkt_t *pkt)
     } else {
       struct sk_buff   *skb;
       struct can_frame *frame;
-      union x8h7_can_message x8h7_can_msg;
+      union x8h7_can_frame_message x8h7_can_msg;
 
       skb = alloc_can_skb(priv->net, &frame);
       if (!skb) {
@@ -295,7 +295,7 @@ static void x8h7_can_hook(void *arg, x8h7_pkt_t *pkt)
       /* Copy header from raw byte-stream onto union. */
       memcpy(x8h7_can_msg.buf, pkt->data, X8H7_CAN_HEADER_SIZE);
 
-      /* Extract can_id and can_dlc. Note: x8h7_can_message uses the exact
+      /* Extract can_id and can_dlc. Note: x8h7_can_frame_message uses the exact
        * same flags for signaling extended/standard id mode or remote
        * retransmit request as struct can_frame.
        */
@@ -531,7 +531,7 @@ static void x8h7_can_hw_rx(struct x8h7_can_priv *priv)
  */
 static void x8h7_can_hw_tx(struct x8h7_can_priv *priv, struct can_frame *frame)
 {
-  union x8h7_can_message x8h7_can_msg;
+  union x8h7_can_frame_message x8h7_can_msg;
 
   DBG_PRINT("\n");
 

--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -918,7 +918,7 @@ static ssize_t x8h7_can_ef_store(struct device *dev,
     return -EINVAL;
   }
 
-  ret = x8h7_can_config_filter(priv, idx, id, mask);
+  ret = x8h7_can_config_filter(priv, idx, (CAN_EFF_FLAG | id), mask);
   if (ret) {
     DBG_ERROR("set filter\n");
     return -EIO;

--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -30,7 +30,7 @@
 #define DRIVER_NAME "x8h7_can"
 
 /* DEBUG HANDLING */
- #define DEBUG
+// #define DEBUG
 #include "debug.h"
 #ifdef DEBUG
   #define DBG_CAN_STATE(d, s) { \
@@ -532,7 +532,7 @@ static void x8h7_can_hw_tx(struct x8h7_can_priv *priv, struct can_frame *frame)
 {
   union x8h7_can_frame_message x8h7_can_msg;
 #ifdef DEBUG
-  char  data_str[X8H7_CAN_FRAME_MAX_DATA_LEN * 4] = {0};
+  char  data_str[X8H7_CAN_FRAME_MAX_DATA_LEN * 4];
   int   i;
   int   len;
 #endif
@@ -549,11 +549,11 @@ static void x8h7_can_hw_tx(struct x8h7_can_priv *priv, struct can_frame *frame)
 
 #ifdef DEBUG
   i = 0; len = 0;
-  for (i = 0; (i < frame->can_dlc) && (len < sizeof(data_str)); i++)
+  for (i = 0; (i < x8h7_can_msg.field.len) && (len < sizeof(data_str)); i++)
   {
-    len += snprintf(data_str + len, sizeof(data_str) - len, " %02X", can_msg.field.data[i]);
+    len += snprintf(data_str + len, sizeof(data_str) - len, " %02X", x8h7_can_msg.field.data[i]);
   }
-  DBG_PRINT("Send CAN frame to H7: id = %08X, len = %d, data = [%s ]\n", can_msg.field.id, can_msg.field.len, data_str);
+  DBG_PRINT("Send CAN frame to H7: id = %08X, len = %d, data = [%s ]\n", x8h7_can_msg.field.id, x8h7_can_msg.field.len, data_str);
 #endif
 
   x8h7_pkt_enq(priv->periph,

--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -84,7 +84,7 @@ RX1IE: Receive Buffer 1 Full I      questo non serve
 
 /**
  */
-union x8h7_can_filter
+union x8h7_can_filter_message
 {
   struct __attribute__((packed))
   {
@@ -795,7 +795,7 @@ static const struct net_device_ops x8h7_can_netdev_ops = {
 static int x8h7_can_config_filter(struct x8h7_can_priv *priv,
                                   const char *buf, int type)
 {
-  union x8h7_can_filter x8h7_can_filter_msg;
+  union x8h7_can_filter_message x8h7_can_filter_msg;
   u32   idx;
   u32   id;
   u32   mask;

--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -824,7 +824,8 @@ static ssize_t x8h7_can_sf_show(struct device *dev,
   int                   i;
 
   len = 0;
-  for (i=0; i<X8H7_STD_FLT_MAX; i++) {
+  for (i = 0; i < X8H7_STD_FLT_MAX; i++)
+  {
     if (priv->std_flt[i].can_mask) {
       len += snprintf(buf + len, PAGE_SIZE - len,
                       "%02X %08X %08X\n",

--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -78,7 +78,6 @@ RX1IE: Receive Buffer 1 Full I      questo non serve
 #define AFTER_SUSPEND_POWER   4
 #define AFTER_SUSPEND_RESTART 8
 
-#define X8H7_FLT_EXT      0x80000000
 #define X8H7_STD_FLT_MAX  128
 #define X8H7_EXT_FLT_MAX   64
 

--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -792,10 +792,10 @@ static const struct net_device_ops x8h7_can_netdev_ops = {
 
 /**
  */
-static int x8h7_can_config_filter(struct x8h7_can_priv *priv,
-                                  uint32_t const idx,
-                                  uint32_t const id,
-                                  uint32_t const mask)
+static int x8h7_can_hw_config_filter(struct x8h7_can_priv *priv,
+                                     uint32_t const idx,
+                                     uint32_t const id,
+                                     uint32_t const mask)
 {
   union x8h7_can_filter_message x8h7_msg;
 
@@ -858,7 +858,7 @@ static ssize_t x8h7_can_sf_store(struct device *dev,
     return -EINVAL;
   }
 
-  ret = x8h7_can_config_filter(priv, idx, id, mask);
+  ret = x8h7_can_hw_config_filter(priv, idx, id, mask);
   if (ret) {
     DBG_ERROR("set filter\n");
     return -EIO;
@@ -918,7 +918,7 @@ static ssize_t x8h7_can_ef_store(struct device *dev,
     return -EINVAL;
   }
 
-  ret = x8h7_can_config_filter(priv, idx, (CAN_EFF_FLAG | id), mask);
+  ret = x8h7_can_hw_config_filter(priv, idx, (CAN_EFF_FLAG | id), mask);
   if (ret) {
     DBG_ERROR("set filter\n");
     return -EIO;

--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -30,7 +30,7 @@
 #define DRIVER_NAME "x8h7_can"
 
 /* DEBUG HANDLING */
-// #define DEBUG
+ #define DEBUG
 #include "debug.h"
 #ifdef DEBUG
   #define DBG_CAN_STATE(d, s) { \
@@ -531,6 +531,11 @@ static void x8h7_can_hw_rx(struct x8h7_can_priv *priv)
 static void x8h7_can_hw_tx(struct x8h7_can_priv *priv, struct can_frame *frame)
 {
   union x8h7_can_frame_message x8h7_can_msg;
+#ifdef DEBUG
+  char  data_str[X8H7_CAN_FRAME_MAX_DATA_LEN * 4] = {0};
+  int   i;
+  int   len;
+#endif
 
   DBG_PRINT("\n");
 
@@ -543,9 +548,7 @@ static void x8h7_can_hw_tx(struct x8h7_can_priv *priv, struct can_frame *frame)
   memcpy(x8h7_can_msg.field.data, frame->data, x8h7_can_msg.field.len);
 
 #ifdef DEBUG
-  char  data_str[X8H7_CAN_FRAME_MAX_DATA_LEN * 4] = {0};
-  int   i = 0, len = 0;
-
+  i = 0; len = 0;
   for (i = 0; (i < frame->can_dlc) && (len < sizeof(data_str)); i++)
   {
     len += snprintf(data_str + len, sizeof(data_str) - len, " %02X", can_msg.field.data[i]);

--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -849,19 +849,19 @@ static ssize_t x8h7_can_sf_store(struct device *dev,
 
   if (ret != 3) {
     DBG_ERROR("invalid num of params\n");
-    return -1;
+    return -EINVAL;
   }
 
   if ((idx >= X8H7_STD_FLT_MAX) ||
       (id & ~0x7FF) || (mask & ~0x7FF)) {
     DBG_ERROR("invalid params\n");
-    return -1;
+    return -EINVAL;
   }
 
   ret = x8h7_can_config_filter(priv, idx, id, mask);
   if (ret) {
     DBG_ERROR("set filter\n");
-    return -1;
+    return -EIO;
   }
 
   priv->std_flt[idx].can_id   = id;
@@ -909,19 +909,19 @@ static ssize_t x8h7_can_ef_store(struct device *dev,
 
   if (ret != 3) {
     DBG_ERROR("invalid num of params\n");
-    return -1;
+    return -EINVAL;
   }
 
   if ((idx >= X8H7_EXT_FLT_MAX) ||
       (id & ~0x1FFFFFFF) || (mask & ~0x1FFFFFFF)) {
     DBG_ERROR("invalid params\n");
-    return -1;
+    return -EINVAL;
   }
 
   ret = x8h7_can_config_filter(priv, idx, id, mask);
   if (ret) {
     DBG_ERROR("set filter\n");
-    return -1;
+    return -EIO;
   }
 
   priv->ext_flt[idx].can_id   = id;

--- a/recipes-kernel/linux-firmware/linux-firmware-arduino-portenta-x8-stm32h7_git.bb
+++ b/recipes-kernel/linux-firmware/linux-firmware-arduino-portenta-x8-stm32h7_git.bb
@@ -16,7 +16,7 @@ SRC_URI = " \
     file://monitor-m4-elf-file.path \
     file://monitor-m4-elf-file.service \
 "
-SRCREV = "665930e420b74c685a07bb05feb5a5677d8f1e65"
+SRCREV = "9aec9248a53b0bc1e0ea8a887da44a2bfc5c5bb5"
 PV = "0.0.2"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Related to https://github.com/arduino/portentax8-stm32h7-fw/pull/28.