### PR TITLE
[x8h7_can] Disable CAN module when Linux CAN driver is closed

### DIFF
--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -44,11 +44,12 @@
 #define X8H7_CAN1_PERIPH  0x03
 #define X8H7_CAN2_PERIPH  0x04
 // Op code
-#define X8H7_CAN_OC_CFG   0x10
-#define X8H7_CAN_OC_SEND  0x01
-#define X8H7_CAN_OC_RECV  0x01
-#define X8H7_CAN_OC_STS   0x40
-#define X8H7_CAN_OC_FLT   0x50
+#define X8H7_CAN_OC_CFG     0x10
+#define X8H7_CAN_OC_DEINIT  0x11
+#define X8H7_CAN_OC_SEND    0x01
+#define X8H7_CAN_OC_RECV    0x01
+#define X8H7_CAN_OC_STS     0x40
+#define X8H7_CAN_OC_FLT     0x50
 
 #define X8H7_CAN_STS_INT_TX      0x01
 #define X8H7_CAN_STS_INT_RX      0x02
@@ -702,6 +703,9 @@ static int x8h7_can_stop(struct net_device *net)
   struct x8h7_can_priv *priv = netdev_priv(net);
 
   DBG_PRINT("\n");
+
+  x8h7_pkt_enq(priv->periph, X8H7_CAN_OC_DEINIT, 0, NULL);
+  x8h7_pkt_send();
 
   close_candev(net);
   priv->force_quit = 1;

--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -348,43 +348,6 @@ static int x8h7_can_pkt_get(struct x8h7_can_priv *priv)
 
 /**
  */
-static int x8h7_can_hw_reset(struct x8h7_can_priv *priv)
-{
-  DBG_PRINT("\n");
-/*
-  unsigned long timeout;
-  int ret;
-
-  // Wait for oscillator startup timer after power up
-  mdelay(MCP251X_OST_DELAY_MS);
-
-  priv->spi_tx_buf[0] = INSTRUCTION_RESET;
-  ret = mcp251x_spi_trans(spi, 1);
-  if (ret)
-    return ret;
-
-  // Wait for oscillator startup timer after reset
-  mdelay(MCP251X_OST_DELAY_MS);
-
-  // Wait for reset to finish
-  timeout = jiffies + HZ;
-  while ((mcp251x_read_reg(spi, CANSTAT) & CANCTRL_REQOP_MASK) !=
-        CANCTRL_REQOP_CONF) {
-    usleep_range(MCP251X_OST_DELAY_MS * 1000,
-          MCP251X_OST_DELAY_MS * 1000 * 2);
-
-    if (time_after(jiffies, timeout)) {
-      dev_err(&spi->dev,
-        "MCP251x didn't enter in conf mode after reset\n");
-      return -EBUSY;
-    }
-  }
-*/
-  return 0;
-}
-
-/**
- */
 static void x8h7_can_clean(struct net_device *net)
 {
   struct x8h7_can_priv *priv = netdev_priv(net);
@@ -603,7 +566,7 @@ static void x8h7_can_restart_work_handler(struct work_struct *ws)
   DBG_PRINT("\n");
   mutex_lock(&priv->lock);
   if (priv->after_suspend) {
-    x8h7_can_hw_reset(priv);
+    x8h7_can_hw_stop(priv);
     x8h7_can_hw_setup(priv);
     priv->force_quit = 0;
     if (priv->after_suspend & AFTER_SUSPEND_RESTART) {
@@ -663,7 +626,7 @@ static int x8h7_can_open(struct net_device *net)
 
   mutex_init(&priv->lock);
 
-  ret = x8h7_can_hw_reset(priv);
+  ret = x8h7_can_hw_stop(priv);
   if (ret) {
     goto out_free_wq;
   }

--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -443,35 +443,11 @@ static int x8h7_can_hw_stop(struct x8h7_can_priv *priv)
  */
 static int x8h7_can_set_normal_mode(struct x8h7_can_priv *priv)
 {
-//  unsigned long  timeout;
-
   DBG_PRINT("\n");
+
   /* Enable interrupts */
   x8h7_hook_set(priv->periph, x8h7_can_hook, priv);
 
-  if (priv->can.ctrlmode & CAN_CTRLMODE_LOOPBACK) {
-    /* Put device into loopback mode */
-    DBG_PRINT("Put device into loopback mode\n");
-  } else if (priv->can.ctrlmode & CAN_CTRLMODE_LISTENONLY) {
-    /* Put device into listen-only mode */
-    DBG_PRINT("Put device into listen-only mode\n");
-  } else {
-    /* Put device into normal mode */
-    DBG_PRINT("Put device into normal mode. Can wait for the device to enter normal mode\n");
-
-    //mcp251x_write_reg(spi, CANCTRL, CANCTRL_REQOP_NORMAL);
-
-    /* Wait for the device to enter normal mode */
-    /*timeout = jiffies + HZ;
-    while (mcp251x_read_reg(spi, CANSTAT) & CANCTRL_REQOP_MASK) {
-      schedule();
-      if (time_after(jiffies, timeout)) {
-        dev_err(&spi->dev, "MCP251x didn't enter in normal mode\n");
-        return -EBUSY;
-      }
-    }*/
-  }
-  priv->can.state = CAN_STATE_ERROR_ACTIVE;
   return 0;
 }
 

--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -329,25 +329,6 @@ static void x8h7_can_hook(void *arg, x8h7_pkt_t *pkt)
 
 /**
  */
-/*
-static int x8h7_can_pkt_get(struct x8h7_can_priv *priv)
-{
-  long ret;
-
-  ret = wait_event_interruptible_timeout(priv->wait,
-                                         priv->rx_cnt != 0,
-                                         X8H7_RX_TIMEOUT);
-  if (!ret) {
-    DBG_ERROR("timeout expired");
-    return -1;
-  }
-  priv->rx_cnt--;
-  return 0;
-}
-*/
-
-/**
- */
 static void x8h7_can_clean(struct net_device *net)
 {
   struct x8h7_can_priv *priv = netdev_priv(net);

--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -431,6 +431,16 @@ static int x8h7_can_hw_setup(struct x8h7_can_priv *priv)
 
 /**
  */
+static int x8h7_can_hw_stop(struct x8h7_can_priv *priv)
+{
+  x8h7_pkt_enq(priv->periph, X8H7_CAN_OC_DEINIT, 0, NULL);
+  x8h7_pkt_send();
+
+  return 0;
+}
+
+/**
+ */
 static int x8h7_can_set_normal_mode(struct x8h7_can_priv *priv)
 {
 //  unsigned long  timeout;
@@ -715,8 +725,7 @@ static int x8h7_can_stop(struct net_device *net)
 
   DBG_PRINT("\n");
 
-  x8h7_pkt_enq(priv->periph, X8H7_CAN_OC_DEINIT, 0, NULL);
-  x8h7_pkt_send();
+  x8h7_can_hw_stop(priv);
 
   close_candev(net);
   priv->force_quit = 1;

--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -44,7 +44,7 @@
 #define X8H7_CAN1_PERIPH  0x03
 #define X8H7_CAN2_PERIPH  0x04
 // Op code
-#define X8H7_CAN_OC_CFG     0x10
+#define X8H7_CAN_OC_INIT    0x10
 #define X8H7_CAN_OC_DEINIT  0x11
 #define X8H7_CAN_OC_SEND    0x01
 #define X8H7_CAN_OC_RECV    0x01
@@ -412,7 +412,7 @@ static int x8h7_can_setup(struct x8h7_can_priv *priv)
 
   DBG_PRINT("frequency_requested = %d\n", frequency_requested);
 
-  x8h7_pkt_enq(priv->periph, X8H7_CAN_OC_CFG, sizeof(frequency_requested), &(frequency_requested));
+  x8h7_pkt_enq(priv->periph, X8H7_CAN_OC_INIT, sizeof(frequency_requested), &(frequency_requested));
   x8h7_pkt_send();
 
   return 0;

--- a/recipes-kernel/linux-firmware/linux-firmware-arduino-portenta-x8-stm32h7_git.bb
+++ b/recipes-kernel/linux-firmware/linux-firmware-arduino-portenta-x8-stm32h7_git.bb
@@ -16,7 +16,7 @@ SRC_URI = " \
     file://monitor-m4-elf-file.path \
     file://monitor-m4-elf-file.service \
 "
-SRCREV = "d61601c36fd0dc26f806ab83b8627fafbdccb812"
+SRCREV = "8f7ce69a77266a84c07b29f23e45b68e4c332610"
 PV = "0.0.3"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
If this is not done, the H7 firmware driver continues to send up CAN frames via the X8H7 SPI bridge which leads to interrupts and consumed CPU cycles on the X8, even though the user does not need the CAN peripheral anymore.

Requires https://github.com/arduino/portentax8-stm32h7-fw/pull/37 .