### PR TITLE
[x8h7] increase transfer speed of SPI bridge from 10 MHz to 25 MHz.

### DIFF
--- a/recipes-bsp/device-tree/lmp-device-tree/portenta-x8/ov_som_x8h7.dts
+++ b/recipes-bsp/device-tree/lmp-device-tree/portenta-x8/ov_som_x8h7.dts
@@ -61,7 +61,7 @@
 				pinctrl-0 = <&pinctrl_irq_x8h7>, <&pinctrl_gpio_x8h7>;
 				interrupt-parent = <&gpio1>;
 				interrupts = <9 IRQ_TYPE_LEVEL_LOW>;
-				spi-max-frequency = <10000000>;
+				spi-max-frequency = <50000000>;
 			};
 		};
 	};

--- a/recipes-kernel/kernel-modules/x8h7/x8h7_drv.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_drv.c
@@ -429,7 +429,7 @@ static int x8h7_probe(struct spi_device *spi)
   spidev->spi = spi;
   mutex_init(&spidev->buf_lock);
 
-  spidev->speed_hz = spi->max_speed_hz;
+  spidev->speed_hz = 25*1000*1000UL;
 
   status = 0;
 


### PR DESCRIPTION
This is well within the acceptable parameter range of both IMX8 and STM32H747 (see links to datasheets and pages/tables in the commit comments of this pull request).

Also, it works :+1: :grin: 