### PR TITLE
[X8H7 FW/RPC] Adjust RPC interface to latest version made available in ArduinoCore-mbed for M4 core.

### DIFF
--- a/recipes-connectivity/m4-proxy/m4-proxy.bb
+++ b/recipes-connectivity/m4-proxy/m4-proxy.bb
@@ -16,7 +16,7 @@ SRC_URI = " \
     git://${GO_IMPORT}.git;protocol=https;destsuffix=${BPN}-${PV}/src/${GO_IMPORT};branch=master \
     file://m4-proxy.service \
 "
-SRCREV = "b9af564047a2db923443dbc360d1393a24fb5409"
+SRCREV = "51a9327f50da14eb4885870325641f453a3205b6"
 
 inherit go-mod
 

--- a/recipes-kernel/linux-firmware/linux-firmware-arduino-portenta-x8-stm32h7_git.bb
+++ b/recipes-kernel/linux-firmware/linux-firmware-arduino-portenta-x8-stm32h7_git.bb
@@ -16,7 +16,7 @@ SRC_URI = " \
     file://monitor-m4-elf-file.path \
     file://monitor-m4-elf-file.service \
 "
-SRCREV = "42d4b1556c2702de3b55786802470bd7db9e640a"
+SRCREV = "e2078c7bab6548f17559823479e2811afa20f197"
 PV = "0.0.3"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This change ensures that both the m4_proxy as well as the H7 firmware have the same OpenAmp interface that a sketch compiled for the M4 core using ArduinoCore-mbed after https://github.com/arduino/ArduinoCore-mbed/commit/3b561693a7f4ce6628c8404a044c873e19a31634 still work.