### PR TITLE
Add CI workflow to check for commonly misspelled words

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,9 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check/.codespellrc
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = ois,
+skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
+builtin = clear,informal,en-GB_to_en-US
+check-filenames =
+check-hidden =

--- a/.codespellrc
+++ b/.codespellrc
@@ -2,7 +2,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = ois,
+ignore-words-list = licence,grey,iterm,parm,ser,som,
 skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,22 @@
+name: Spell Check
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 `meta-partner-arduino`
 ======================
+[![Spell Check](https://github.com/arduino/meta-partner-arduino/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino/meta-partner-arduino/actions/workflows/spell-check.yml)
 [![Sync Labels status](https://github.com/arduino/meta-partner-arduino/actions/workflows/sync-labels.yml/badge.svg)](https://github.com/arduino/meta-partner-arduino/actions/workflows/sync-labels.yml)
 
 This repository contains [Yocto](https://www.yoctoproject.org/) recipes for building a Linux image for the Arduino [Portenta X8](https://store.arduino.cc/products/portenta-x8).

--- a/recipes-bsp/device-tree/lmp-device-tree/portenta-mx8mm/ov_carrier_enuc_rs485h_sp330.dts
+++ b/recipes-bsp/device-tree/lmp-device-tree/portenta-mx8mm/ov_carrier_enuc_rs485h_sp330.dts
@@ -6,7 +6,7 @@
  * Gpios:
  * DE controls tx
  * REn controls rx
- * behaviour is always rx except while transmitting. Direction
+ * behavior is always rx except while transmitting. Direction
  * is handled by driver with gpios, no direct hardware control
  */
 

--- a/recipes-bsp/device-tree/lmp-device-tree/portenta-x8/ov_carrier_ditto_base.dts
+++ b/recipes-bsp/device-tree/lmp-device-tree/portenta-x8/ov_carrier_ditto_base.dts
@@ -16,7 +16,7 @@
  * - Ethernet phy configured in u-boot
  * - USB2514B/M2 hub configured in u-boot
  * - UART2 is shell cmd
- * - EEPROM I2C1 address 0xAE readed in u-boot (auto carrier detection)
+ * - EEPROM I2C1 address 0xAE read in u-boot (auto carrier detection)
  */
 
 /dts-v1/;

--- a/recipes-bsp/u-boot/u-boot-fio/portenta-mx8mm/0001-portenta-m8-add-initial-board-support.patch
+++ b/recipes-bsp/u-boot/u-boot-fio/portenta-mx8mm/0001-portenta-m8-add-initial-board-support.patch
@@ -1743,7 +1743,7 @@ index 0000000000..48cc92f359
 +	{ 0x13730, 0x0 },
 +	{ 0x13830, 0x0 },
 +};
-+/* P0 message block paremeter for training firmware */
++/* P0 message block parameter for training firmware */
 +struct dram_cfg_param ddr_fsp0_cfg[] = {
 +	{ 0xd0000, 0x0 },
 +	{ 0x54003, 0xbb8 },
@@ -1782,7 +1782,7 @@ index 0000000000..48cc92f359
 +};
 +
 +
-+/* P1 message block paremeter for training firmware */
++/* P1 message block parameter for training firmware */
 +struct dram_cfg_param ddr_fsp1_cfg[] = {
 +	{ 0xd0000, 0x0 },
 +	{ 0x54002, 0x101 },
@@ -1822,7 +1822,7 @@ index 0000000000..48cc92f359
 +};
 +
 +
-+/* P2 message block paremeter for training firmware */
++/* P2 message block parameter for training firmware */
 +struct dram_cfg_param ddr_fsp2_cfg[] = {
 +	{ 0xd0000, 0x0 },
 +	{ 0x54002, 0x102 },
@@ -1862,7 +1862,7 @@ index 0000000000..48cc92f359
 +};
 +
 +
-+/* P0 2D message block paremeter for training firmware */
++/* P0 2D message block parameter for training firmware */
 +struct dram_cfg_param ddr_fsp0_2d_cfg[] = {
 +	{ 0xd0000, 0x0 },
 +	{ 0x54003, 0xbb8 },

--- a/recipes-bsp/u-boot/u-boot-fio/portenta-mx8mm/0002-portenta-m8-sync-with-imx8mm_evk.patch
+++ b/recipes-bsp/u-boot/u-boot-fio/portenta-mx8mm/0002-portenta-m8-sync-with-imx8mm_evk.patch
@@ -4,7 +4,7 @@ Date: Mon, 11 Oct 2021 16:03:52 -0700
 Subject: [PATCH 02/45] portenta-m8: sync with imx8mm_evk
 
 - add bootm_size var
-- replace more ocurrances of fdt_addr with fdt_addr_r
+- replace more occurrences of fdt_addr with fdt_addr_r
 - replace 5 with nandrootfs setting for ubi.mtd kernel param
 
 Signed-off-by: Michael Scott <mike@foundries.io>

--- a/recipes-bsp/u-boot/u-boot-fio/portenta-mx8mm/0009-Added-Portenta-X8-hw-support-need-to-test.patch
+++ b/recipes-bsp/u-boot/u-boot-fio/portenta-mx8mm/0009-Added-Portenta-X8-hw-support-need-to-test.patch
@@ -1749,7 +1749,7 @@ index 0000000000..48cc92f359
 +	{ 0x13730, 0x0 },
 +	{ 0x13830, 0x0 },
 +};
-+/* P0 message block paremeter for training firmware */
++/* P0 message block parameter for training firmware */
 +struct dram_cfg_param ddr_fsp0_cfg[] = {
 +	{ 0xd0000, 0x0 },
 +	{ 0x54003, 0xbb8 },
@@ -1788,7 +1788,7 @@ index 0000000000..48cc92f359
 +};
 +
 +
-+/* P1 message block paremeter for training firmware */
++/* P1 message block parameter for training firmware */
 +struct dram_cfg_param ddr_fsp1_cfg[] = {
 +	{ 0xd0000, 0x0 },
 +	{ 0x54002, 0x101 },
@@ -1828,7 +1828,7 @@ index 0000000000..48cc92f359
 +};
 +
 +
-+/* P2 message block paremeter for training firmware */
++/* P2 message block parameter for training firmware */
 +struct dram_cfg_param ddr_fsp2_cfg[] = {
 +	{ 0xd0000, 0x0 },
 +	{ 0x54002, 0x102 },
@@ -1868,7 +1868,7 @@ index 0000000000..48cc92f359
 +};
 +
 +
-+/* P0 2D message block paremeter for training firmware */
++/* P0 2D message block parameter for training firmware */
 +struct dram_cfg_param ddr_fsp0_2d_cfg[] = {
 +	{ 0xd0000, 0x0 },
 +	{ 0x54003, 0xbb8 },

--- a/recipes-bsp/u-boot/u-boot-fio/portenta-mx8mm/0021-portenta-common-establish-common-files-for-Portenta-.patch
+++ b/recipes-bsp/u-boot/u-boot-fio/portenta-mx8mm/0021-portenta-common-establish-common-files-for-Portenta-.patch
@@ -1179,7 +1179,7 @@ index 48cc92f359..0000000000
 -	{ 0x13730, 0x0 },
 -	{ 0x13830, 0x0 },
 -};
--/* P0 message block paremeter for training firmware */
+-/* P0 message block parameter for training firmware */
 -struct dram_cfg_param ddr_fsp0_cfg[] = {
 -	{ 0xd0000, 0x0 },
 -	{ 0x54003, 0xbb8 },
@@ -1218,7 +1218,7 @@ index 48cc92f359..0000000000
 -};
 -
 -
--/* P1 message block paremeter for training firmware */
+-/* P1 message block parameter for training firmware */
 -struct dram_cfg_param ddr_fsp1_cfg[] = {
 -	{ 0xd0000, 0x0 },
 -	{ 0x54002, 0x101 },
@@ -1258,7 +1258,7 @@ index 48cc92f359..0000000000
 -};
 -
 -
--/* P2 message block paremeter for training firmware */
+-/* P2 message block parameter for training firmware */
 -struct dram_cfg_param ddr_fsp2_cfg[] = {
 -	{ 0xd0000, 0x0 },
 -	{ 0x54002, 0x102 },
@@ -1298,7 +1298,7 @@ index 48cc92f359..0000000000
 -};
 -
 -
--/* P0 2D message block paremeter for training firmware */
+-/* P0 2D message block parameter for training firmware */
 -struct dram_cfg_param ddr_fsp0_2d_cfg[] = {
 -	{ 0xd0000, 0x0 },
 -	{ 0x54003, 0xbb8 },

--- a/recipes-bsp/u-boot/u-boot-fio/portenta-mx8mm/0027-portenta-common-anx7625-additional-changes-to-u-boot.patch
+++ b/recipes-bsp/u-boot/u-boot-fio/portenta-mx8mm/0027-portenta-common-anx7625-additional-changes-to-u-boot.patch
@@ -49,7 +49,7 @@ index df08dffdca..6c0be4ff44 100644
 + * DRP mode: after connection we switch between Rp(DFP) and Rd(UFP) until we detect a valid connection. When
 + * connection is detected, start either in UFP or DFP mode.
 + * The DFP sends SOURCE_CAPS in loop immediately after connection and waits for ack.
-+ * In case DFP becames SINK (or SINK becames DFP like in our case) then SINK needs to send SNK_CAPS that need
++ * In case DFP becomes SINK (or SINK becomes DFP like in our case) then SINK needs to send SNK_CAPS that need
 + * to be accepted by other device. This is because current sink may be different between DFP and UFP modes.
 + * In DFP only mode we can switch data role (became DFP) after POWER_RDY message. The Rp/Rd connection
 + * remains fixed, only data role is changed.

--- a/recipes-bsp/u-boot/u-boot-fio/portenta-mx8mm/0035-A-few-adjs-to-anx-driver-and-doc.patch
+++ b/recipes-bsp/u-boot/u-boot-fio/portenta-mx8mm/0035-A-few-adjs-to-anx-driver-and-doc.patch
@@ -25,7 +25,7 @@ index 49f1b3be68..c075eac8f5 100644
  #define ANX7625_NEGOTIATE_PD          1
  #define ANX7625_NEGOTIATE_ERROR       1 /* If defined when negotiation fails blink red led repeatedly to warn the user and doesn't boot into kernel */
 -#define ANX7625_NEGOTIATE_ENDS_SETUP  1 /* If defined exits immediately after power negotiation is finished */
-+#define ANX7625_NEGOTIATE_ENDS_SETUP  1 /* If defined exits immediately after power negotiation is finished, otherwise waits for the timeout to occours */
++#define ANX7625_NEGOTIATE_ENDS_SETUP  1 /* If defined exits immediately after power negotiation is finished, otherwise waits for the timeout to occurs */
  
  static uint8_t last_chip_addr;
  

--- a/recipes-bsp/u-boot/u-boot-fio/portenta-mx8mm/0048-Added-VBUS-switch-management.patch
+++ b/recipes-bsp/u-boot/u-boot-fio/portenta-mx8mm/0048-Added-VBUS-switch-management.patch
@@ -51,7 +51,7 @@ index 208065b228..cde30533d5 100644
  #define ANX7625_NEGOTIATE_PD          1
 -#define ANX7625_NEGOTIATE_ERROR       1 /* If defined when negotiation fails blink red led repeatedly to warn the user and doesn't boot into kernel */
 +#define ANX7625_LOOP_ON_ERROR         1 /* If defined when negotiation fails blink red led repeatedly to warn the user and doesn't boot into kernel */
- #define ANX7625_NEGOTIATE_ENDS_SETUP  1 /* If defined exits immediately after power negotiation is finished, otherwise waits for the timeout to occours */
+ #define ANX7625_NEGOTIATE_ENDS_SETUP  1 /* If defined exits immediately after power negotiation is finished, otherwise waits for the timeout to occurs */
  
  static uint8_t last_chip_addr;
 @@ -162,6 +177,10 @@ static void request_gpios(void)

--- a/recipes-kernel/kernel-modules/anx7625/anx7625.c
+++ b/recipes-kernel/kernel-modules/anx7625/anx7625.c
@@ -1366,7 +1366,7 @@ static int anx7625_chip_register_init(struct anx7625_data *ctx)
 	return ret;
 }
 
-/* Pd disable means you are not gonna using pd negotiation */
+/* Pd disable means you are not going to using pd negotiation */
 static void anx7625_disable_pd_protocol(struct anx7625_data *ctx)
 {
 	struct device *dev = &ctx->client->dev;
@@ -1390,7 +1390,7 @@ static void anx7625_disable_pd_protocol(struct anx7625_data *ctx)
 		DRM_DEV_DEBUG_DRIVER(dev, "disable PD feature succeeded.\n");
 }
 
-/* Pd disable means you are not gonna using pd negotiation */
+/* Pd disable means you are not going to using pd negotiation */
 static int anx7625_enable_pd_protocol(struct anx7625_data *ctx)
 {
 	struct device *dev = &ctx->client->dev;

--- a/recipes-kernel/kernel-modules/dtbocfg/dtbocfg.c
+++ b/recipes-kernel/kernel-modules/dtbocfg/dtbocfg.c
@@ -128,7 +128,7 @@ static int dtbocfg_overlay_item_create(struct dtbocfg_overlay_item *overlay)
 }
 
 /**
- * dtbocfg_overlay_item_release() - Relase Device Tree Overlay
+ * dtbocfg_overlay_item_release() - Release Device Tree Overlay
  * @overlay: Pointer to Device Tree Overlay Item
  * return    none
  */
@@ -155,7 +155,7 @@ static inline struct dtbocfg_overlay_item* container_of_dtbocfg_overlay_item(str
 }
 
 /**
- * dtbocfg_overlay_item_status_store() - Set Status Attibute
+ * dtbocfg_overlay_item_status_store() - Set Status Attribute
  * @item:  Pointer to Configuration Item
  * @page:  Pointer to Value Buffer
  * @count: Size of Value Buffer Size
@@ -184,7 +184,7 @@ static ssize_t dtbocfg_overlay_item_status_store(struct config_item *item, const
 }
 
 /**
- * dtbocfg_overlay_item_status_show() - Show Status Attibute
+ * dtbocfg_overlay_item_status_show() - Show Status Attribute
  * @item : Pointer to Configuration Item
  * @page : Pointer to Value for Store
  * return  String Size or Error Status.

--- a/recipes-kernel/kernel-modules/imx219/imx219.c
+++ b/recipes-kernel/kernel-modules/imx219/imx219.c
@@ -99,7 +99,7 @@
 #define IMX219_TEST_PATTERN_GREY_COLOR	3
 #define IMX219_TEST_PATTERN_PN9		4
 
-/* Test pattern colour components */
+/* Test pattern color components */
 #define IMX219_REG_TESTP_RED		0x0602
 #define IMX219_REG_TESTP_GREENR		0x0604
 #define IMX219_REG_TESTP_BLUE		0x0606
@@ -442,8 +442,8 @@ static const u32 codes[] = {
 };
 
 /*
- * Initialisation delay between XCLR low->high and the moment when the sensor
- * can start capture (i.e. can leave software stanby) must be not less than:
+ * Initialization delay between XCLR low->high and the moment when the sensor
+ * can start capture (i.e. can leave software standby) must be not less than:
  *   t4 + max(t5, t6 + <time to initialize the sensor register over I2C>)
  * where
  *   t4 is fixed, and is max 200uS,
@@ -943,7 +943,7 @@ static int imx219_set_pad_format(struct v4l2_subdev *sd,
 					 exposure_def);
 		/*
 		 * Currently PPL is fixed to IMX219_PPL_DEFAULT, so hblank
-		 * depends on mode->width only, and is not changeble in any
+		 * depends on mode->width only, and is not changeable in any
 		 * way other than changing the mode.
 		 */
 		hblank = IMX219_PPL_DEFAULT - mode->width;

--- a/recipes-kernel/kernel-modules/imx477/imx477.c
+++ b/recipes-kernel/kernel-modules/imx477/imx477.c
@@ -97,7 +97,7 @@ MODULE_PARM_DESC(trigger_mode, "Set vsync trigger mode: 1=source, 2=sink");
 #define IMX477_TEST_PATTERN_GREY_COLOR	3
 #define IMX477_TEST_PATTERN_PN9		4
 
-/* Test pattern colour components */
+/* Test pattern color components */
 #define IMX477_REG_TEST_PATTERN_R	0x0602
 #define IMX477_REG_TEST_PATTERN_GR	0x0604
 #define IMX477_REG_TEST_PATTERN_B	0x0606
@@ -1078,7 +1078,7 @@ static const char * const imx477_supply_name[] = {
 #define IMX477_NUM_SUPPLIES ARRAY_SIZE(imx477_supply_name)
 
 /*
- * Initialisation delay between XCLR low->high and the moment when the sensor
+ * Initialization delay between XCLR low->high and the moment when the sensor
  * can start capture (i.e. can leave software standby), given by T7 in the
  * datasheet is 8ms.  This does include I2C setup time as well.
  *
@@ -1307,7 +1307,7 @@ static void imx477_adjust_exposure_range(struct imx477 *imx477)
 {
 	int exposure_max, exposure_def;
 
-	/* Honour the VBLANK limits when setting exposure. */
+	/* Honor the VBLANK limits when setting exposure. */
 	exposure_max = imx477->mode->height + imx477->vblank->val -
 		       IMX477_EXPOSURE_OFFSET;
 	exposure_def = min(exposure_max, imx477->exposure->val);

--- a/recipes-kernel/kernel-modules/imx708/imx708.c
+++ b/recipes-kernel/kernel-modules/imx708/imx708.c
@@ -73,7 +73,7 @@
 #define IMX708_DGTL_GAIN_DEFAULT	0x0100
 #define IMX708_DGTL_GAIN_STEP		1
 
-/* Colour balance controls */
+/* Color balance controls */
 #define IMX708_REG_COLOUR_BALANCE_RED   0x0b90
 #define IMX708_REG_COLOUR_BALANCE_BLUE	0x0b92
 #define IMX708_COLOUR_BALANCE_MIN	0x01
@@ -89,7 +89,7 @@
 #define IMX708_TEST_PATTERN_GREY_COLOR	3
 #define IMX708_TEST_PATTERN_PN9		4
 
-/* Test pattern colour components */
+/* Test pattern color components */
 #define IMX708_REG_TEST_PATTERN_R	0x0602
 #define IMX708_REG_TEST_PATTERN_GR	0x0604
 #define IMX708_REG_TEST_PATTERN_B	0x0606
@@ -797,7 +797,7 @@ static const char * const imx708_supply_name[] = {
 };
 
 /*
- * Initialisation delay between XCLR low->high and the moment when the sensor
+ * Initialization delay between XCLR low->high and the moment when the sensor
  * can start capture (i.e. can leave software standby), given by T7 in the
  * datasheet is 8ms.  This does include I2C setup time as well.
  *
@@ -1047,7 +1047,7 @@ static void imx708_adjust_exposure_range(struct imx708 *imx708,
 {
 	int exposure_max, exposure_def;
 
-	/* Honour the VBLANK limits when setting exposure. */
+	/* Honor the VBLANK limits when setting exposure. */
 	exposure_max = imx708->mode->height + imx708->vblank->val -
 		IMX708_EXPOSURE_OFFSET;
 	exposure_def = min(exposure_max, imx708->exposure->val);

--- a/recipes-kernel/kernel-modules/ov5647-mipi/ov5647_mipi.c
+++ b/recipes-kernel/kernel-modules/ov5647-mipi/ov5647_mipi.c
@@ -996,7 +996,7 @@ err:
 }
 
 /* sensor changes between scaling and subsampling
- * go through exposure calcualtion
+ * go through exposure calculation
  */
 static int ov5647_change_mode_exposure_calc(enum ov5647_frame_rate frame_rate,
 				enum ov5647_mode mode)
@@ -1154,7 +1154,7 @@ static int ov5647_init_mode(enum ov5647_frame_rate frame_rate,
 	} else if ((dn_mode == SUBSAMPLING && orig_dn_mode == SCALING) ||
 			(dn_mode == SCALING && orig_dn_mode == SUBSAMPLING)) {
 		/* change between subsampling and scaling
-		 * go through exposure calucation */
+		 * go through exposure calculation */
 		retval = ov5647_change_mode_exposure_calc(frame_rate, mode);
 	} else {
 		/* change inside subsampling or scaling
@@ -1288,7 +1288,7 @@ static int ov5647_s_parm(struct v4l2_subdev *sd, struct v4l2_streamparm *a)
 	struct i2c_client *client = v4l2_get_subdevdata(sd);
 	struct ov5647 *sensor = to_ov5647(client);
 	struct v4l2_fract *timeperframe = &a->parm.capture.timeperframe;
-	u32 tgt_fps;	/* target frames per secound */
+	u32 tgt_fps;	/* target frames per second */
 	enum ov5647_frame_rate frame_rate;
 	enum ov5647_mode orig_mode;
 	int ret = 0;
@@ -1496,7 +1496,7 @@ static int ov5647_enum_frameintervals(struct v4l2_subdev *sd,
 static int init_device(void)
 {
 	u32 tgt_xclk;	/* target xclk */
-	u32 tgt_fps;	/* target frames per secound */
+	u32 tgt_fps;	/* target frames per second */
 	enum ov5647_frame_rate frame_rate;
 	int ret;
 

--- a/recipes-kernel/kernel-modules/x8h7/x8h7_h7.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_h7.c
@@ -216,7 +216,7 @@ static ssize_t x8h7_h7_write(struct file *file,
 
   ret = copy_from_user(data, buf, len);
   if (ret) {
-    DBG_ERROR("Could't copy %zd bytes from the user\n", ret);
+    DBG_ERROR("Couldn't copy %zd bytes from the user\n", ret);
     return -EFAULT;
   }
 

--- a/recipes-kernel/kernel-modules/x8h7/x8h7_uart.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_uart.c
@@ -272,7 +272,7 @@ static void x8h7_uart_stop_rx(struct uart_port *port)
 /**
  * Return TIOCSER_TEMT when transmitter is not busy.
  * @TODO: need to understand when H7 is still busy
- * in trasmitting data on uart due to slower throughput in
+ * in transmitting data on uart due to slower throughput in
  * comparison with spi. Introduce status byte?
  */
 static unsigned int x8h7_uart_tx_empty(struct uart_port *port)

--- a/recipes-kernel/kernel-modules/x8h7/x8h7_ui.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_ui.c
@@ -86,7 +86,7 @@ static ssize_t x8h7_ui_read(struct file *file,
   wait_event_interruptible(wq, priv->rx_len != 0);
 
   *offset = 0;
-  //DBG_PRINT("cpoy to user %d bytes\n", count);
+  //DBG_PRINT("copy to user %d bytes\n", count);
   ret = simple_read_from_buffer(buf, count, offset, priv->rx_data, priv->rx_len);
   priv->rx_len = 0;
 
@@ -108,7 +108,7 @@ static ssize_t x8h7_ui_write(struct file *file,
 
   ret = copy_from_user(data, buf, len);
   if (ret) {
-    DBG_ERROR("Could't copy %zd bytes from the user\n", ret);
+    DBG_ERROR("Couldn't copy %zd bytes from the user\n", ret);
     return -EFAULT;
   }
 


### PR DESCRIPTION
On every push, pull request, and periodically, use codespell to check for commonly misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the field of . Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.