### PR TITLE
Fix: properly cleanup when shutting CAN interface down.

### DIFF
--- a/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
+++ b/recipes-kernel/kernel-modules/x8h7/x8h7_can.c
@@ -664,6 +664,7 @@ static int x8h7_can_stop(struct net_device *net)
   DBG_PRINT("\n");
 
   x8h7_can_hw_stop(priv);
+  x8h7_can_clean(net);
 
   close_candev(net);
   priv->force_quit = 1;


### PR DESCRIPTION
This is achieved by invoking `x8h7_can_clean` within `x8h7_can_stop`.