### PR TITLE
Add udev rules

### DIFF
--- a/recipes-core/udev/udev-rules-portenta.bb
+++ b/recipes-core/udev/udev-rules-portenta.bb
@@ -4,6 +4,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 SRC_URI = " \
     file://65-apex.rules \
+    file://90-arduino-devices.rules \
 "
 
 S = "${WORKDIR}"
@@ -13,4 +14,5 @@ INHIBIT_DEFAULT_DEPS = "1"
 do_install () {
     install -d ${D}${sysconfdir}/udev/rules.d
     install -m 0644 ${WORKDIR}/65-apex.rules ${D}${sysconfdir}/udev/rules.d/
+    install -m 0644 ${WORKDIR}/90-arduino-devices.rules ${D}${sysconfdir}/udev/rules.d/
 }

--- a/recipes-core/udev/udev-rules-portenta/90-arduino-devices.rules
+++ b/recipes-core/udev/udev-rules-portenta/90-arduino-devices.rules
@@ -1,0 +1,35 @@
+# Arduino custome device names to make them easier to find in /dev/arduino/
+#
+# %n the "kernel number" of the device.
+#    For example, 'sda3' has a "kernel number" of '3'
+# %e the smallest number for that name which does not matches an existing node
+# %k the kernel name for the device
+# %M the kernel major number for the device
+# %m the kernel minor number for the device
+# %b the bus id for the device
+# %c the string returned by the PROGRAM
+# %s{filename} the content of a sysfs attribute
+# %% the '%' char itself
+#
+
+# I2c
+SUBSYSTEM=="i2c-dev", KERNEL=="i2c-2", SYMLINK+="arduino/i2c0"
+SUBSYSTEM=="i2c-dev", KERNEL=="i2c-1", SYMLINK+="arduino/i2c1"
+SUBSYSTEM=="i2c-dev", KERNEL=="i2c-3", SYMLINK+="arduino/i2c2"
+
+# Uart
+SUBSYSTEM=="tty", KERNEL=="ttyX0", SYMLINK+="arduino/uart0"
+SUBSYSTEM=="tty", KERNEL=="ttyX1", SYMLINK+="arduino/uart1"
+SUBSYSTEM=="tty", KERNEL=="ttyX2", SYMLINK+="arduino/uart2"
+SUBSYSTEM=="tty", KERNEL=="ttyX3", SYMLINK+="arduino/uart3"
+
+# Spi
+SUBSYSTEM=="spidev", KERNEL=="spidev0.0", SYMLINK+="arduino/spi0"
+SUBSYSTEM=="spidev", KERNEL=="spidev1.0", SYMLINK+="arduino/spi1"
+
+# Storage
+SUBSYSTEM=="block", KERNEL=="mmcblk2", SYMLINK+="arduino/mmc"
+SUBSYSTEM=="block", KERNEL=="mmcblk2p[1-9]", SYMLINK+="arduino/mmc%n"
+SUBSYSTEM=="block", KERNEL=="mmcblk1", SYMLINK+="arduino/sdcard"
+SUBSYSTEM=="block", KERNEL=="mmcblk1p[1-9]", SYMLINK+="arduino/sdcard%n"
+

--- a/recipes-core/udev/udev-rules-portenta/90-arduino-devices.rules
+++ b/recipes-core/udev/udev-rules-portenta/90-arduino-devices.rules
@@ -1,4 +1,4 @@
-# Arduino custome device names to make them easier to find in /dev/arduino/
+# Arduino custom device names to make them easier to find in /dev/arduino/
 #
 # %n the "kernel number" of the device.
 #    For example, 'sda3' has a "kernel number" of '3'


### PR DESCRIPTION
\Use udev symlinks to have unique device names fore arduino boards.