### PR TITLE
Fix uart device mappping

### DIFF
--- a/recipes-core/udev/udev-rules-portenta/90-arduino-devices.rules
+++ b/recipes-core/udev/udev-rules-portenta/90-arduino-devices.rules
@@ -19,9 +19,9 @@ SUBSYSTEM=="i2c-dev", KERNEL=="i2c-3", SYMLINK+="arduino/i2c2"
 
 # Uart
 SUBSYSTEM=="tty", KERNEL=="ttyX0", SYMLINK+="arduino/uart0"
-SUBSYSTEM=="tty", KERNEL=="ttyX1", SYMLINK+="arduino/uart1"
-SUBSYSTEM=="tty", KERNEL=="ttyX2", SYMLINK+="arduino/uart2"
-SUBSYSTEM=="tty", KERNEL=="ttyX3", SYMLINK+="arduino/uart3"
+SUBSYSTEM=="tty", KERNEL=="ttymxc1", SYMLINK+="arduino/uart1"
+SUBSYSTEM=="tty", KERNEL=="ttymxc2", SYMLINK+="arduino/uart2"
+SUBSYSTEM=="tty", KERNEL=="ttymxc3", SYMLINK+="arduino/uart3"
 
 # Spi
 SUBSYSTEM=="spidev", KERNEL=="spidev0.0", SYMLINK+="arduino/spi0"


### PR DESCRIPTION
Udev rules to symlink devices must use this map
uart0: /dev/tt0X0
uart1: /dev/ttymxc1
uart2: /dev/ttymxc2
uart3: /dev/ttymxc3